### PR TITLE
Fix issues with paths when using windows

### DIFF
--- a/lib/engine/filesystem.js
+++ b/lib/engine/filesystem.js
@@ -21,10 +21,12 @@
  */
 
 const _ = require('lodash');
-const path = require('path');
 const Bluebird = require('bluebird');
 const imagefs = require('resin-image-fs');
 const formats = require('./formats');
+
+// Use POSIX paths everywhere, not your local OS format
+const path = require('path').posix;
 
 /**
  * @summary Check if a file declaration represents a virtual file

--- a/tests/integration/write.spec.js
+++ b/tests/integration/write.spec.js
@@ -131,17 +131,17 @@ ava.test('should be able to modify a fileset', (test) => {
       cellular: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'cellular')
+        path: path.posix.join(schema.files.system_connections.location.path, 'cellular')
       }),
       ethernet: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'ethernet')
+        path: path.posix.join(schema.files.system_connections.location.path, 'ethernet')
       }),
       wifi: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'wifi')
+        path: path.posix.join(schema.files.system_connections.location.path, 'wifi')
       })
     });
   };
@@ -181,17 +181,17 @@ ava.test('should not override custom properties inside a fileset', (test) => {
       cellular: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'cellular')
+        path: path.posix.join(schema.files.system_connections.location.path, 'cellular')
       }),
       ethernet: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'ethernet')
+        path: path.posix.join(schema.files.system_connections.location.path, 'ethernet')
       }),
       wifi: imagefs.readFile({
         image: image,
         partition: schema.files.system_connections.location.partition,
-        path: path.join(schema.files.system_connections.location.path, 'wifi')
+        path: path.posix.join(schema.files.system_connections.location.path, 'wifi')
       })
     });
   };
@@ -200,7 +200,7 @@ ava.test('should not override custom properties inside a fileset', (test) => {
     return imagefs.writeFile({
       image: imagePath,
       partition: schema.files.system_connections.location.partition,
-      path: path.join(schema.files.system_connections.location.path, 'cellular')
+      path: path.posix.join(schema.files.system_connections.location.path, 'cellular')
     }, '[connection]\nname=cellular\nfoo=bar\nbar=baz').then(() => {
       return reconfix.writeConfiguration(schema, {
         cellularConnectionName: 'newcellular',


### PR DESCRIPTION
I know we're moving away from this JS implementation soon, but it'd be very useful to get this in in the short-term anyway as a quick fix to unblock https://github.com/resin-io-modules/resin-device-init/pull/25, where this currently breaks OS configuration in Windows.

Right now, reconfix breaks on windows because it tries to pass paths like `\\system-connections\\resin-wifi` to `resin-image-fs`, which is having none of it, and claims that file doesn't exist.

That is the right OS-local separator, but it completely doesn't work for resin-image-fs (as far as I can tell, that expects `/` all the time). This PR changes this to always generate paths like `/system-connections/resin-wifi` instead, which always works, regardless of the local platform.