### PR TITLE
Enable degree heuristic for template matching.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
         "**/CVS": true,
         "**/.DS_Store": true,
         "**/*.rs.bk": true
-    }
+    },
+    "rust-client.channel": "nightly-2018-01-21"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reconfix"
 description = "bidirectional data transformation engine"
-version = "0.1.0"
+version = "0.2.1"
 authors = ["Aaron Brodersen <aaron@resin.io>"]
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,11 @@ version = "0.1.0"
 authors = ["Aaron Brodersen <aaron@resin.io>"]
 license = "Apache-2.0"
 
+[dev-dependencies]
+env_logger = "0.4"
+
 [dependencies]
-log = "0.3"
+log = "0.4"
 serde = "1.0"
 regex = "0.2"
 error-chain = "0.11"

--- a/bindings/node/native/Cargo.toml
+++ b/bindings/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-reconfix"
-version = "0.1.0"
+version = "0.2.1"
 authors = ["Aaron Brodersen <aaron@resin.io>"]
 license = "Apache-2.0"
 build = "build.rs"

--- a/bindings/node/native/src/task.rs
+++ b/bindings/node/native/src/task.rs
@@ -92,6 +92,7 @@ impl Task for ReadTask {
 
         debug!("invoking read dispatcher callback");
         callback.call(scope, JsUndefined::new(), args)?;
+        debug!("read dispatcher callback returned");
 
         let sender = self.tx.clone();
         self.schedule(noop(scope, sender)?);
@@ -186,6 +187,7 @@ impl Task for WriteTask {
 
         debug!("invoking write dispatcher callback");
         callback.call(scope, JsUndefined::new(), args)?;
+        debug!("write dispatcher callback returned");
 
         let sender = self.tx.clone();
         self.schedule(noop(scope, sender)?);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reconfix-preview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reconfix-preview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Node.js wrapper for the Reconfix library.",
   "main": "bindings/node/lib/index.js",
   "author": "Aaron Brodersen <aaron@resin.io>",

--- a/src/template.rs
+++ b/src/template.rs
@@ -99,18 +99,17 @@ pub fn degree(pattern: &Value) -> u64 {
 mod tests {
 
     use super::matches;
+    use test::*;
     use serde_json::Value;
 
-    fn template_matches(data: Vec<String>) -> Option<String> {
-        let msg = &data[0];
-        let value = data[1].parse::<Value>().expect("Invalid JSON value!");
-        let pattern = data[2].parse::<Value>().expect("Invalid JSON pattern!");
-        let expected = &*data[3];
-        let result = matches(&value, &pattern);
+    fn template_matches(data: &str) {
+        let (msg, value, pattern, expected) =
+            parse_test_data(data, |x| Result::Ok::<Value, ()>(x.clone()));
+        let result = matches(&value.unwrap(), &pattern);
         match (expected, result) {
-            ("true", true) => None,
-            ("false", false) => None,
-            _ => Some(msg.clone()),
+            (Some(Value::Bool(x)), y) => assert_eq!(x, y, "{}", msg),
+            (Some(x), _) => assert!(false, "{}: invalid expected value '{}'", msg, x),
+            _ => assert!(false, "{}: missing expected value", msg),
         }
     }
 
@@ -120,10 +119,8 @@ mod tests {
             fn $name() {
                 let file_contents = include_str!(concat!("../tests/testdata/template/",
                                                          stringify!($name)));
-                match template_matches(file_contents.split('\n').map(String::from).collect()) {
-                    None => { },
-                    Some(s) => assert!(false, s),
-                }
+                template_matches(file_contents);
+
             }
         )* )
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -64,6 +64,15 @@ where
     items
 }
 
+/// Helper function for parsing the multi-line test files. Assumes they follow the format:
+///
+/// 1. Test name in a `# comment`
+/// 2. Schema JSON
+/// 3. Input JSON
+/// 4. Expected output JSON
+///
+/// A callback is provided for parsing the schema into a different structure before returning
+/// values to the calling test.
 pub fn parse_test_data<T, F>(data: &str, convert: F) -> (String, T, Value, Option<Value>)
 where
     F: FnOnce(&Value) -> T,

--- a/tests/testdata/mapping/bidi_7
+++ b/tests/testdata/mapping/bidi_7
@@ -1,4 +1,7 @@
 # disambiguate matching templates based on degree
-[{"value":"foo", "template":{"foo":1}},{"value":"foobar","template":{"foo":1,"bar":2}}]
+[
+    {"value":"foo", "template":{"foo":1}},
+    {"value":"foobar","template":{"foo":1,"bar":2}}
+]
 {"foo":1,"bar":2}
 "foobar"

--- a/tests/testdata/mapping/unmap_7
+++ b/tests/testdata/mapping/unmap_7
@@ -1,0 +1,7 @@
+# match template with higher degree
+[
+    {"value":1, "template":{"foo":1}},
+    {"value":2, "template":{"foo":1,"bar":2}}
+]
+{"foo":1,"bar":2}
+2

--- a/tests/testdata/template/matches_1
+++ b/tests/testdata/template/matches_1
@@ -1,4 +1,4 @@
-return true if subset matches
+# return true if subset matches
 {"foo":{"bar":2,"baz":{"qux":5}}}
 {"foo":{"bar":2}}
 true

--- a/tests/testdata/template/matches_10
+++ b/tests/testdata/template/matches_10
@@ -1,4 +1,4 @@
-return true if a number wildcard matches
+# return true if a number wildcard matches
 {"foo":{"bar":3}}
 {"foo":{"bar":"[[number]]"}}
 true

--- a/tests/testdata/template/matches_11
+++ b/tests/testdata/template/matches_11
@@ -1,4 +1,4 @@
-return false if a number wildcard does not match
+# return false if a number wildcard does not match
 {"foo":{"bar":"3"}}
 {"foo":{"bar":"[[number]]"}}
 false

--- a/tests/testdata/template/matches_12
+++ b/tests/testdata/template/matches_12
@@ -1,4 +1,4 @@
-return true if a boolean wildcard matches
+# return true if a boolean wildcard matches
 {"foo":{"bar":false}}
 {"foo":{"bar":"[[boolean]]"}}
 true

--- a/tests/testdata/template/matches_13
+++ b/tests/testdata/template/matches_13
@@ -1,4 +1,4 @@
-return true if a boolean wildcard does not match
+# return true if a boolean wildcard does not match
 {"foo":{"bar":"true"}}
 {"foo":{"bar":"[[boolean]]"}}
 false

--- a/tests/testdata/template/matches_14
+++ b/tests/testdata/template/matches_14
@@ -1,4 +1,4 @@
-return true if an object wildcard matches
+# return true if an object wildcard matches
 {"foo":{"bar":{"qux":1,"hello":{"world":3}}}}
 {"foo":"[[object]]"}
 true

--- a/tests/testdata/template/matches_15
+++ b/tests/testdata/template/matches_15
@@ -1,4 +1,4 @@
-return false if an object wildcard does not match
+# return false if an object wildcard does not match
 {"foo":{"bar":[1,2,3]}}
 {"foo":{"bar":"[[object]]"}}
 false

--- a/tests/testdata/template/matches_16
+++ b/tests/testdata/template/matches_16
@@ -1,4 +1,4 @@
-return false if an array wildcard does not match
+# return false if an array wildcard does not match
 {"foo":{"bar":{"baz":[1,2,3]}}}
 {"foo":{"bar":"[[array]]"}}
 false

--- a/tests/testdata/template/matches_2
+++ b/tests/testdata/template/matches_2
@@ -1,4 +1,4 @@
-return false if the template is a superset of the data
+# return false if the template is a superset of the data
 {"foo":{"bar":2}}
 {"foo":{"bar":2},"baz":{"qux":5}}
 false

--- a/tests/testdata/template/matches_3
+++ b/tests/testdata/template/matches_3
@@ -1,4 +1,4 @@
-return false if subset does not match
+# return false if subset does not match
 {"foo":{"bar":2,"baz":{"qux":5}}}
 {"foo":{"qux":2}}
 false

--- a/tests/testdata/template/matches_4
+++ b/tests/testdata/template/matches_4
@@ -1,4 +1,4 @@
-return false if an array is a subset of the other
+# return false if an array is a subset of the other
 {"foo":{"bar":[1,2,3]}}
 {"foo":{"bar":[1,2]}}
 false

--- a/tests/testdata/template/matches_5
+++ b/tests/testdata/template/matches_5
@@ -1,4 +1,4 @@
-return false if arrays do not match
+# return false if arrays do not match
 {"foo":{"bar":[1,2,3]}}
 {"foo":{"bar":[0,1,2]}}
 false

--- a/tests/testdata/template/matches_6
+++ b/tests/testdata/template/matches_6
@@ -1,4 +1,4 @@
-return true if arrays match entirely
+# return true if arrays match entirely
 {"foo":{"bar":[1,2,3]}}
 {"foo":{"bar":[1,2,3]}}
 true

--- a/tests/testdata/template/matches_7
+++ b/tests/testdata/template/matches_7
@@ -1,4 +1,4 @@
-throw if a wildcard type is invalid
+# throw if a wildcard type is invalid
 {"foo":{"bar":"baz"}}
 {"foo":{"bar":"[[foo]]"}}
 #error

--- a/tests/testdata/template/matches_8
+++ b/tests/testdata/template/matches_8
@@ -1,4 +1,4 @@
-return true if a string wildcard matches
+# return true if a string wildcard matches
 {"foo":{"bar":"foo bar"}}
 {"foo":{"bar":"[[string]]"}}
 true

--- a/tests/testdata/template/matches_9
+++ b/tests/testdata/template/matches_9
@@ -1,4 +1,4 @@
-return false if a string wildcard does not match
+# return false if a string wildcard does not match
 {"foo":{"bar":1}}
 {"foo":{"bar":"[[string]]"}}
 false


### PR DESCRIPTION
If one template is a subset of the other, we need a heuristic for determining which template is the match.

For example: 
````
{"foo":1,"bar":2}
````
should have a higher priority than
````
{"foo": 1}
````

A degree function has already been defined in the code. It's definition looks like:
````
degree (o: object) = o.keys().map(degree).sum()
degree (a: array) = a.map(degree).sum()
degree (_) = 1
````