### PR TITLE
Update resin-image-fs, to use a Node 10 compatible ext2fs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: cpp
 sudo: false
 
 env:
-  - NODE_VERSION="6"
-  - NODE_VERSION="8"
+  - NODE_VERSION="6" UV_THREADPOOL_SIZE="16"
+  - NODE_VERSION="8" UV_THREADPOOL_SIZE="16"
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 env:
   - NODE_VERSION="6" UV_THREADPOOL_SIZE="16"
   - NODE_VERSION="8" UV_THREADPOOL_SIZE="16"
+  - NODE_VERSION="10" UV_THREADPOOL_SIZE="16"
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ cache:
   - '%AppData%\npm-cache'
 
 environment:
+  UV_THREADPOOL_SIZE: 16
   matrix:
     - nodejs_version: 6
     - nodejs_version: 8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
   matrix:
     - nodejs_version: 6
     - nodejs_version: 8
+    - nodejs_version: 10
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,72 @@
+---
+version: 2
+
+buildSteps: &buildSteps
+  - checkout
+  - run:
+      name: install-npm
+      command: npm install
+  - run:
+      name: test
+      command: npm test
+  - persist_to_workspace:
+      # Persist all job output, so we can (potentially) use it for deploys
+      root: ../
+      paths:
+        - ./node-*
+
+jobs:
+  "node-6":
+    docker:
+      - image: circleci/node:6
+    working_directory: ~/node-6
+    steps: *buildSteps
+
+  "node-8":
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/node-8
+    steps: *buildSteps
+
+  deploy:
+    # For this to work NPM_TOKEN must be set for the account used for publishing
+    docker:
+      - image: circleci/node:6
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Login to npm
+          command: |
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            npm whoami
+      - deploy:
+          name: Deploy to npm
+          command: npm publish
+          # Output used for publish is from node 6 build
+          working_directory: $CIRCLE_WORKING_DIRECTORY/node-6
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "node-6":
+          # Run for all tags (required to allow the deploy to trigger on version tags)
+          filters:
+            tags:
+              only: /.*/
+      - "node-8":
+          # Run for all tags (required to allow the deploy to trigger on version tags)
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          # Deploy passing builds if they're tagged with a version
+          requires:
+            - "node-6"
+            - "node-8"
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,12 @@ jobs:
     working_directory: ~/node-8
     steps: *buildSteps
 
+  "node-10":
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/node-10
+    steps: *buildSteps
+
   deploy:
     # For this to work NPM_TOKEN must be set for the account used for publishing
     docker:
@@ -62,11 +68,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - "node-10":
+          # Run for all tags (required to allow the deploy to trigger on version tags)
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           # Deploy passing builds if they're tagged with a version
           requires:
             - "node-6"
             - "node-8"
+            - "node-10"
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ buildSteps: &buildSteps
       name: install-npm
       command: npm install
   - run:
+      environment:
+        UV_THREADPOOL_SIZE: 16
       name: test
       command: npm test
   - persist_to_workspace:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ini": "^1.3.4",
     "inquirer": "^1.1.3",
     "lodash": "^4.16.2",
-    "resin-image-fs": "^4.1.1",
+    "resin-image-fs": "^5.0.4",
     "rindle": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reconfix",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "(Re)Configuration toolkit",
   "main": "lib/index.js",
   "homepage": "https://github.com/resin-io/reconfix",


### PR DESCRIPTION
Key difference is just that it means we transitively depend on a far newer ext2fs (^1.0.0), which will support Node 10 properly, thereby making the CLI easier to install. This is needed downstream to fix Node 10 compatibility in resin-device-init, to fix compatibility downstream in resin-cli.

I don't think this has any externally visible breaking code changes for resin-device-init, afaict. Is that right @zvin? ~~The changelog in resin-image-fs is major, but doesn't say what's broken.~~

Edit: this does change node version compatibility - with this change, reconfix requires Node v6, so I'm planning to releasing it as 0.1.0.

I've added our standard circle config in here (and set up an npm token), because circle is enabled and without that it tries to build in Node 4, which fails.

Change-Type: patch