### PR TITLE
JS API which wraps cdsl, reconfix & temen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,14 @@ crate-type = ["lib", "cdylib"]
 travis-ci = { repository = "balena-io/reconfix", branch = "master" }
 
 [dependencies.balena-temen]
-version = "0"
+# 0.5.1 introduces disable-wasm-bindings features
+version = "~0.5.1"
+features = ["disable-wasm-bindings"]
+
+[dependencies.balena-cdsl]
+# 0.10.4 introduces disable-wasm-bindings features
+version = "~0.10.4"
+features = ["disable-wasm-bindings"]
 
 [dependencies.base64]
 version = "0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@
   <sub>an open source :satellite: project by <a href="https://www.balena.io">balena.io</a></sub>
 </div>
 
-**EXPERIMENTAL**
+## EXPERIMENTAL
+
+Version:
+
+* `< 1.0` - initial NodeJS implementation
+* `>= 1.0 && < 2.0` - experimental Rust implementation with different API & functionality
+* `>= 2.0` - will be used for initial stable Rust based release
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   <sub>an open source :satellite: project by <a href="https://www.balena.io">balena.io</a></sub>
 </div>
 
+**EXPERIMENTAL**
+
 ## Support
 
 If you're having any problem, please [raise an issue] on GitHub or [contact us], and the [balena.io] team

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 
-echo "Skipping deployment, crate not ready"
-exit 0
-
 set -e
 
 source "${HOME}/.cargo/env"
 source "${HOME}/.nvm/nvm.sh"
 nvm use
 
-echo "Authenticating to crates.io..."
-cargo login "${CARGO_API_TOKEN}"
-echo "Publishing Rust crate..."
-cargo publish
-
+# TODO Uncomment to enable crate publishing once done
+#
+# echo "Authenticating to crates.io..."
+# cargo login "${CARGO_API_TOKEN}"
+# echo "Publishing Rust crate..."
+# cargo publish
 
 echo "Authenticating to npmjs.org registry..."
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc

--- a/node/tests/src/jelly-schema/constructor.test.js
+++ b/node/tests/src/jelly-schema/constructor.test.js
@@ -1,0 +1,56 @@
+const rcx = require('reconfix');
+
+test('can be instantiated from a string', () => {
+    expect(
+        new rcx.JellySchema('title: Foo\nversion: 1\n')
+    ).toBeDefined();
+});
+
+test('can be instantiated from an object', () => {
+    expect(
+        new rcx.JellySchema({
+            title: 'Foo',
+            version: 1
+        })
+    ).toBeDefined();
+});
+
+test('throws in case of invalid schema (string)', () => {
+    expect(
+        () => {
+            js = new rcx.JellySchema('foo');
+        }
+    ).toThrow();
+});
+
+test('throws in case of invalid schema (boolean)', () => {
+    expect(
+        () => {
+            js = new rcx.JellySchema(true);
+        }
+    ).toThrow();
+});
+
+test('throws in case of invalid schema (undefined)', () => {
+    expect(
+        () => {
+            js = new rcx.JellySchema(undefined);
+        }
+    ).toThrow();
+});
+
+test('throws in case of invalid schema (null)', () => {
+    expect(
+        () => {
+            js = new rcx.JellySchema(null);
+        }
+    ).toThrow();
+});
+
+test('throws in case of invalid schema (number)', () => {
+    expect(
+        () => {
+            js = new rcx.JellySchema(10);
+        }
+    ).toThrow();
+});

--- a/node/tests/src/jelly-schema/errors.test.js
+++ b/node/tests/src/jelly-schema/errors.test.js
@@ -1,0 +1,49 @@
+const rcx = require('reconfix');
+
+test('no errors after instantiation', () => {
+    expect(
+        new rcx.JellySchema({
+            title: 'Foo',
+            version: 1
+        }).errors()
+    ).toEqual([]);
+});
+
+test('errors are cleared if validation succeeds', () => {
+    js = new rcx.JellySchema({
+        type: 'integer'
+    });
+    expect(js.validate('foo')).toBeFalsy();
+    expect(js.errors().length).toBeGreaterThan(0);
+    expect(js.validate(10)).toBeTruthy();
+    expect(js.errors().length).toBe(0);
+});
+
+test('errors are cleared if validation fails', () => {
+    js = new rcx.JellySchema({
+        type: 'integer'
+    });
+    expect(js.validate('foo')).toBeFalsy();
+    errors_count = js.errors().length;
+    expect(errors_count).toBeGreaterThan(0);
+    expect(js.validate('foo')).toBeFalsy();
+    expect(errors_count).toBe(js.errors().length);
+});
+
+test('errors are cleared if validation throws', () => {
+    js = new rcx.JellySchema({
+        type: 'integer'
+    });
+
+    expect(js.validate('foo')).toBeFalsy();
+    expect(js.errors().length).toBeGreaterThan(0);
+
+    try {
+        js.validate(undefined);
+        expect('must throw').toEqual('did not');
+    } catch (e) {
+        expect(e).toBeDefined();
+    }
+
+    expect(js.errors().length).toBe(0);
+});

--- a/node/tests/src/jelly-schema/jsonAndUiSchema.test.js
+++ b/node/tests/src/jelly-schema/jsonAndUiSchema.test.js
@@ -1,0 +1,48 @@
+const rcx = require('reconfix');
+
+test('string validation', () => {
+    js = new rcx.JellySchema({
+        title: "Foo",
+        properties: [
+            {
+                name: {
+                    type: "string",
+                    title: "Name",
+                    description: "Your full name"
+                }
+            }
+        ]
+    });
+
+    expected = {
+        jsonSchema: {
+            "$$order": [
+                "name"
+            ],
+            "$$version": 1,
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            additionalProperties: false,
+            properties: {
+                name: {
+                    title: "Name",
+                    type: "string"
+                }
+            },
+            required: [
+                "name"
+            ],
+            title: "Foo",
+            type: "object"
+        },
+        uiSchema: {
+            name: {
+                "ui:description": "Your full name"
+            },
+            "ui:order": [
+                "name"
+            ]
+        }
+    };
+
+    expect(js.jsonAndUiSchema()).toEqual(expected);
+});

--- a/node/tests/src/jelly-schema/validate.test.js
+++ b/node/tests/src/jelly-schema/validate.test.js
@@ -1,0 +1,25 @@
+const rcx = require('reconfix');
+
+test('validate throws if the input is invalid', () => {
+    js = new rcx.JellySchema({
+        type: "string",
+        pattern: "^[0-9]+$"
+    });
+
+    expect(
+        () => {
+            js.validate(undefined)
+        }
+    ).toThrow();
+})
+
+test('string validation', () => {
+    js = new rcx.JellySchema({
+        type: "string",
+        pattern: "^[0-9]+$",
+        minLength: 3
+    });
+    expect(js.validate("123")).toBeTruthy();
+    expect(js.validate("12")).toBeFalsy();
+    expect(js.validate("foo")).toBeFalsy();
+});

--- a/node/tests/src/require.test.js
+++ b/node/tests/src/require.test.js
@@ -1,4 +1,0 @@
-test('reconfix require', () => {
-    const reconfix = require('reconfix');
-    expect(reconfix).toBeDefined();
-});

--- a/node/tests/src/temen/evaluate.test.js
+++ b/node/tests/src/temen/evaluate.test.js
@@ -1,0 +1,39 @@
+const rcx = require('reconfix');
+
+test('validate throws if the input is invalid', () => {
+    expect(
+        () => {
+            rcx.evaluate(undefined)
+        }
+    ).toThrow();
+})
+
+test('same object is returned if there is nothing to evaluate', () => {
+    data = {
+        foo: 'bar',
+        bar: 'baz',
+        baz: 10
+    };
+
+    expect(rcx.evaluate(data)).toEqual(data);
+})
+
+test('math expression', () => {
+    data = {
+        '$$formula': '1+1'
+    };
+
+    expect(rcx.evaluate(data)).toEqual(2);
+})
+
+test('math expression with references', () => {
+    data = {
+        x: 10,
+        y: 20,
+        sum: {
+            '$$formula': 'x + y'
+        }
+    };
+
+    expect(rcx.evaluate(data).sum).toEqual(30);
+})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod error;
 pub mod schema;
 mod utils;
 pub mod validator;
+#[cfg(target_arch = "wasm32")]
+mod wasm;

--- a/src/validator/error.rs
+++ b/src/validator/error.rs
@@ -1,9 +1,12 @@
+use serde_derive::Serialize;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ValidationError {
     keyword: String,
+    #[serde(rename = "schemaPath")]
     schema_path: String,
+    #[serde(rename = "dataPath")]
     data_path: String,
     message: String,
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -5,8 +5,9 @@ use crate::{
     utils::value,
 };
 
+pub use error::ValidationError;
 use scope::ScopedSchema;
-use state::ValidationState;
+pub use state::ValidationState;
 
 mod error;
 mod path;

--- a/src/validator/scope.rs
+++ b/src/validator/scope.rs
@@ -94,8 +94,6 @@ impl<'a> ScopedSchema<'a> {
         let mut schema_path = self.schema_path().clone();
         schema_path.push_property(keyword.clone());
 
-        let schema_path = format!("#{}", schema_path);
-
-        ValidationError::new(keyword, schema_path, self.data_path().to_string(), message)
+        ValidationError::new(keyword, schema_path.to_string(), self.data_path().to_string(), message)
     }
 }

--- a/src/wasm/eval.rs
+++ b/src/wasm/eval.rs
@@ -1,0 +1,26 @@
+use console_error_panic_hook::set_once as set_panic_hook_once;
+use wasm_bindgen::prelude::*;
+
+use balena_temen as temen;
+
+/// Evaluates JSON with `$$formula` keywords
+///
+/// # Arguments
+///
+/// * `data` - A JSON object
+///
+/// # Throws
+///
+/// In case of `data` can't be deserialized with serde.
+#[wasm_bindgen]
+pub fn evaluate(data: &JsValue) -> Result<JsValue, JsValue> {
+    set_panic_hook_once();
+
+    let data = data.into_serde().map_err(|e| JsValue::from(format!("{}", e)))?;
+
+    let evaluated = temen::evaluate(data).map_err(|e| JsValue::from(format!("{}", e)))?;
+
+    let result = JsValue::from_serde(&evaluated).map_err(|e| JsValue::from(format!("{}", e)))?;
+
+    Ok(result)
+}

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,0 +1,114 @@
+use console_error_panic_hook::set_once as set_panic_hook_once;
+use serde_json::{json, Value};
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+use balena_cdsl::output::generator::Generator;
+
+use crate::{
+    schema::Schema,
+    validator::{ValidationState, Validator},
+};
+
+#[wasm_bindgen]
+pub struct JellySchema {
+    jelly_schema: Schema,
+    json_schema: Value,
+    ui_schema: Value,
+    last_validation_state: ValidationState,
+}
+
+mod eval;
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+impl JellySchema {
+    /// Instantiates new JellySchema object
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - JellySchema as a string or an object
+    ///
+    /// # Throws
+    ///
+    /// Constructor throws in case of invalid `schema` argument value.
+    #[wasm_bindgen(constructor)]
+    pub fn constructor(schema: &JsValue) -> Result<JellySchema, JsValue> {
+        set_panic_hook_once();
+
+        let jelly_schema: Schema = if schema.is_string() {
+            Schema::from_str(&schema.as_string().unwrap()).map_err(|e| JsValue::from(format!("{}", e)))?
+        } else {
+            schema.into_serde().map_err(|e| JsValue::from(format!("{}", e)))?
+        };
+
+        let yaml: serde_yaml::Value = if schema.is_string() {
+            serde_yaml::from_str(&schema.as_string().unwrap()).map_err(|e| JsValue::from(format!("{}", e)))?
+        } else {
+            schema.into_serde().map_err(|e| JsValue::from(format!("{}", e)))?
+        };
+
+        let (json_schema, ui_schema) = Generator::with(yaml)
+            .map_err(|e| JsValue::from(format!("{:?}", e)))?
+            .generate();
+
+        Ok(JellySchema {
+            jelly_schema,
+            json_schema,
+            ui_schema,
+            last_validation_state: ValidationState::new(),
+        })
+    }
+
+    /// Validates data against JellySchema
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A JSON object
+    ///
+    /// # Throws
+    ///
+    /// In case of `data` can not be deserialized to a JSON value.
+    pub fn validate(&mut self, data: &JsValue) -> Result<bool, JsValue> {
+        match data.into_serde() {
+            Ok(data) => {
+                self.last_validation_state = self.jelly_schema.validate(Some(&data));
+                Ok(self.last_validation_state.is_valid())
+            }
+            Err(e) => {
+                self.last_validation_state = ValidationState::new();
+                Err(JsValue::from_str(&format!("{}", e)))
+            }
+        }
+    }
+
+    /// Generates JSON Schema & UI Schema object
+    ///
+    /// ```js
+    /// {
+    ///     "jsonSchema": {...},
+    ///     "uiSchema": {...}
+    /// }
+    /// ```
+    ///
+    /// # Throws
+    ///
+    /// In case of internal error only (serde serialization).
+    pub fn jsonAndUiSchema(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&json!({
+            "jsonSchema": self.json_schema,
+            "uiSchema": self.ui_schema,
+        }))
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
+    /// Returns last validation errors
+    ///
+    /// # Throws
+    ///
+    /// In case of internal error only (serde serialization).
+    pub fn errors(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&json!(self.last_validation_state.errors()))
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+}

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -18,7 +18,7 @@ pub struct JellySchema {
     last_validation_state: ValidationState,
 }
 
-mod eval;
+mod temen;
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]

--- a/src/wasm/temen.rs
+++ b/src/wasm/temen.rs
@@ -17,10 +17,6 @@ pub fn evaluate(data: &JsValue) -> Result<JsValue, JsValue> {
     set_panic_hook_once();
 
     let data = data.into_serde().map_err(|e| JsValue::from(format!("{}", e)))?;
-
     let evaluated = temen::evaluate(data).map_err(|e| JsValue::from(format!("{}", e)))?;
-
-    let result = JsValue::from_serde(&evaluated).map_err(|e| JsValue::from(format!("{}", e)))?;
-
-    Ok(result)
+    JsValue::from_serde(&evaluated).map_err(|e| JsValue::from(format!("{}", e)))
 }

--- a/tests/data/error/schema-path/array-index.yaml
+++ b/tests/data/error/schema-path/array-index.yaml
@@ -8,13 +8,13 @@ schema:
             - name:
                 type: string
 tests:
-  - description: "Error schema-path must equal to #properties[0].list.items[0].properties[0].name.type"
+  - description: "Error schema-path must equal to properties[0].list.items[0].properties[0].name.type"
     data:
       list: [{}]
-    schema-path: "#properties[0].list.items[0].properties[0].name.type"
-  - description: "Error schema-path must equal to #properties[1].list.items[0].properties[0].name.type"
+    schema-path: "properties[0].list.items[0].properties[0].name.type"
+  - description: "Error schema-path must equal to properties[1].list.items[0].properties[0].name.type"
     data:
       list:
         - name: foo
         - name: 123
-    schema-path: "#properties[0].list.items[0].properties[0].name.type"
+    schema-path: "properties[0].list.items[0].properties[0].name.type"

--- a/tests/data/error/schema-path/nested-array-index.yaml
+++ b/tests/data/error/schema-path/nested-array-index.yaml
@@ -12,12 +12,12 @@ schema:
                     - name:
                         type: string
 tests:
-  - description: "Error schema-path must equal to #properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
+  - description: "Error schema-path must equal to properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
     data:
       list:
         - seq: [{}]
-    schema-path: "#properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
-  - description: "Error schema-path must equal to #properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
+    schema-path: "properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
+  - description: "Error schema-path must equal to properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
     data:
       list:
         - seq: []
@@ -27,4 +27,4 @@ tests:
             - name: bar
             - name: baz
             - name: 123
-    schema-path: "#properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"
+    schema-path: "properties[0].list.items[0].properties[0].seq.items[0].properties[0].name.type"

--- a/tests/data/error/schema-path/nested-objects-property.yaml
+++ b/tests/data/error/schema-path/nested-objects-property.yaml
@@ -9,21 +9,21 @@ schema:
                     type: string
                     minLength: 10
 tests:
-  - description: "Error schema-path must equal to #properties[0].childA.type"
+  - description: "Error schema-path must equal to properties[0].childA.type"
     data: {}
-    schema-path: "#properties[0].childA.type"
+    schema-path: "properties[0].childA.type"
   - description: "Error schema-path must equal to #properties[0].childA.properties[0].childB.type"
     data:
       childA: {}
-    schema-path: "#properties[0].childA.properties[0].childB.type"
-  - description: "Error schema-path must equal to #properties[0].childA.properties[0].childB.properties[0].name.type"
+    schema-path: "properties[0].childA.properties[0].childB.type"
+  - description: "Error schema-path must equal to properties[0].childA.properties[0].childB.properties[0].name.type"
     data:
       childA:
         childB: {}
-    schema-path: "#properties[0].childA.properties[0].childB.properties[0].name.type"
-  - description: "Error schema-path must equal to #properties[0].childA.properties[0].childB.properties[0].name.minLength"
+    schema-path: "properties[0].childA.properties[0].childB.properties[0].name.type"
+  - description: "Error schema-path must equal to properties[0].childA.properties[0].childB.properties[0].name.minLength"
     data:
       childA:
         childB:
           name: foo
-    schema-path: "#properties[0].childA.properties[0].childB.properties[0].name.minLength"
+    schema-path: "properties[0].childA.properties[0].childB.properties[0].name.minLength"

--- a/tests/data/error/schema-path/root-property.yaml
+++ b/tests/data/error/schema-path/root-property.yaml
@@ -4,6 +4,6 @@ schema:
     - name:
         type: string
 tests:
-  - description: Error schema-path must equal to "#properties[0].name.type"
+  - description: Error schema-path must equal to "properties[0].name.type"
     data: {}
-    schema-path: "#properties[0].name.type"
+    schema-path: "properties[0].name.type"


### PR DESCRIPTION
**Changes**

* enables NPM package publishing
* provides JS API for cdsl, reconfix & temen
* removes `#` prefix from the `ValidationError.schema_path`

**Release**

Bumped major (1.0.0) to distinguish between previous node version & Rust one.

**NOTICE**

* `jsonAndUiSchema()` returns an object with `jsonSchema` & `uiSchema`
  * camel case, no snake case
  * `cdsl` does use `json_schema` & `ui_object`, which isn't JS camel case and also it's not an UI object, but UI schema